### PR TITLE
Added automatic cropping of images modulo 4 to the DefaultPredictor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## [v0.0.2]
 
 ### Added
 
 - The `DefaultPredictor` class now automatically crops the input image
   to dimensions that are a multiple of four.
+  
+### Changed
+- Moved the exceptions associated with the `Predictor` interface into
+  the public `predictors` package.
 
 ## [v0.0.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- The `DefaultPredictor` class now automatically crops the input image
+  to dimensions that are a multiple of four.
+
 ## [v0.0.1]
 
 ### Changed
@@ -14,5 +21,6 @@ All notable changes to this project will be documented in this file.
 
 - Initial project files.
 
+[v0.0.2]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.2
 [v0.0.1]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.1
 [v0.0.0]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,9 +26,9 @@ copyright = '2018, The Laboratory of Experimental Biophysics, EPFL, Lausanne, Sw
 author = 'Baptiste Ottino, Kyle M. Douglass'
 
 # The short X.Y version
-version = '0.0.2-SNAPSHOT'
+version = '0.0.2'
 # The full version, including alpha/beta/rc tags
-release = '0.0.2-SNAPSHOT'
+release = '0.0.2'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,9 +26,9 @@ copyright = '2018, The Laboratory of Experimental Biophysics, EPFL, Lausanne, Sw
 author = 'Baptiste Ottino, Kyle M. Douglass'
 
 # The short X.Y version
-version = '0.0.1'
+version = '0.0.2-SNAPSHOT'
 # The full version, including alpha/beta/rc tags
-release = '0.0.1'
+release = '0.0.2-SNAPSHOT'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     
     <groupId>ch.epfl.leb</groupId>
     <artifactId>DEFCoN_</artifactId>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
 
     <name>DEFCoN-ImageJ</name>
     <description>ImageJ plugin for DEFCoN, a fluorescence spot counter using fully convolutional neural networks.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     
     <groupId>ch.epfl.leb</groupId>
     <artifactId>DEFCoN_</artifactId>
-    <version>0.0.1</version>
+    <version>0.0.2-SNAPSHOT</version>
 
     <name>DEFCoN-ImageJ</name>
     <description>ImageJ plugin for DEFCoN, a fluorescence spot counter using fully convolutional neural networks.</description>

--- a/src/main/java/ch/epfl/leb/defcon/ij/DensityCount.java
+++ b/src/main/java/ch/epfl/leb/defcon/ij/DensityCount.java
@@ -20,9 +20,9 @@ package ch.epfl.leb.defcon.ij;
 
 import ch.epfl.leb.defcon.predictors.Predictor;
 import ch.epfl.leb.defcon.predictors.internal.DefaultPredictor;
-import ch.epfl.leb.defcon.predictors.internal.SessionClosedException;
-import ch.epfl.leb.defcon.predictors.internal.ImageBitDepthException;
-import ch.epfl.leb.defcon.predictors.internal.UninitializedPredictorException;
+import ch.epfl.leb.defcon.predictors.SessionClosedException;
+import ch.epfl.leb.defcon.predictors.ImageBitDepthException;
+import ch.epfl.leb.defcon.predictors.UninitializedPredictorException;
 
 import ij.IJ;
 import ij.ImagePlus;

--- a/src/main/java/ch/epfl/leb/defcon/predictors/ImageBitDepthException.java
+++ b/src/main/java/ch/epfl/leb/defcon/predictors/ImageBitDepthException.java
@@ -16,16 +16,16 @@
  * along with this program.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
-package ch.epfl.leb.defcon.predictors.internal;
+package ch.epfl.leb.defcon.predictors;
 
 /**
- * Raised when a predictor has not yet been fully initialized.
+ * Raised when an image with an invalid bit-depth is supplied to the predictor.
  * 
  * @author Kyle M. Douglass
  */
-public class UninitializedPredictorException extends Exception {
+public class ImageBitDepthException extends Exception {
     
-    public UninitializedPredictorException(String msg) {
+    public ImageBitDepthException(String msg) {
         super(msg);
     }
     

--- a/src/main/java/ch/epfl/leb/defcon/predictors/Predictor.java
+++ b/src/main/java/ch/epfl/leb/defcon/predictors/Predictor.java
@@ -18,9 +18,6 @@
  */
 package ch.epfl.leb.defcon.predictors;
 
-import ch.epfl.leb.defcon.predictors.internal.SessionClosedException;
-import ch.epfl.leb.defcon.predictors.internal.ImageBitDepthException;
-import ch.epfl.leb.defcon.predictors.internal.UninitializedPredictorException;
 
 import ij.process.ImageProcessor;
 import ij.process.FloatProcessor;

--- a/src/main/java/ch/epfl/leb/defcon/predictors/SessionClosedException.java
+++ b/src/main/java/ch/epfl/leb/defcon/predictors/SessionClosedException.java
@@ -16,7 +16,7 @@
  * along with this program.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
-package ch.epfl.leb.defcon.predictors.internal;
+package ch.epfl.leb.defcon.predictors;
 
 /**
  * Raised when a prediction is requested but the TensorFlow session has already been closed.

--- a/src/main/java/ch/epfl/leb/defcon/predictors/UninitializedPredictorException.java
+++ b/src/main/java/ch/epfl/leb/defcon/predictors/UninitializedPredictorException.java
@@ -16,16 +16,16 @@
  * along with this program.  If not, see
  * <http://www.gnu.org/licenses/>.
  */
-package ch.epfl.leb.defcon.predictors.internal;
+package ch.epfl.leb.defcon.predictors;
 
 /**
- * Raised when an image with an invalid bit-depth is supplied to the predictor.
+ * Raised when a predictor has not yet been fully initialized.
  * 
  * @author Kyle M. Douglass
  */
-public class ImageBitDepthException extends Exception {
+public class UninitializedPredictorException extends Exception {
     
-    public ImageBitDepthException(String msg) {
+    public UninitializedPredictorException(String msg) {
         super(msg);
     }
     

--- a/src/main/java/ch/epfl/leb/defcon/predictors/internal/DefaultPredictor.java
+++ b/src/main/java/ch/epfl/leb/defcon/predictors/internal/DefaultPredictor.java
@@ -18,6 +18,9 @@
  */
 package ch.epfl.leb.defcon.predictors.internal;
 
+import ch.epfl.leb.defcon.predictors.ImageBitDepthException;
+import ch.epfl.leb.defcon.predictors.SessionClosedException;
+import ch.epfl.leb.defcon.predictors.UninitializedPredictorException;
 import ch.epfl.leb.defcon.predictors.Predictor;
 
 import ij.gui.Roi;

--- a/src/main/java/ch/epfl/leb/defcon/predictors/internal/DefaultPredictor.java
+++ b/src/main/java/ch/epfl/leb/defcon/predictors/internal/DefaultPredictor.java
@@ -19,13 +19,18 @@
 package ch.epfl.leb.defcon.predictors.internal;
 
 import ch.epfl.leb.defcon.predictors.Predictor;
+
+import ij.gui.Roi;
 import ij.ImagePlus;
 import ij.process.ByteProcessor;
 import ij.process.FloatProcessor;
 import ij.process.ShortProcessor;
 import ij.process.ImageProcessor;
+import java.awt.Rectangle;
+
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 import org.tensorflow.Tensor;
 
 /**
@@ -48,6 +53,22 @@ public class DefaultPredictor extends AbstractPredictor implements Predictor {
      * The most-recently computed density map.
      */
     private FloatProcessor densityMap;
+    
+    /**
+     * Checks that an image's dimensions are divisible by four and crops it if not.
+     * 
+     * This restriction on the size of an image is a requirement of DEFCoN.
+     * 
+     * @return The input image, possibly cropped.
+     */
+    private ImageProcessor checkDimensions(ImageProcessor ip) {
+        
+        Rectangle currRoi = ip.getRoi();
+        ip.setRoi(new Roi(currRoi.x, currRoi.y,
+                          currRoi.width - currRoi.width % 4,
+                          currRoi.height - currRoi.height % 4));
+        return ip.crop();
+    }
     
     /**
      * Returns the most recent count.
@@ -93,6 +114,9 @@ public class DefaultPredictor extends AbstractPredictor implements Predictor {
     /**
      * Makes a density map prediction from a 2D image.
      * 
+     * If either of the image's width or height is not divisible by 4, they will
+     * be cropped to the next largest multiple of four.
+     * 
      * @param ip The image to perform a prediction on.
      */
     @Override
@@ -109,10 +133,10 @@ public class DefaultPredictor extends AbstractPredictor implements Predictor {
         int bitDepth = ip.getBitDepth();
         switch (bitDepth) {
             case 16:
-                predict(ip.convertToShortProcessor());
+                predict(checkDimensions(ip).convertToShortProcessor());
                 break;
             case 8:
-                predict(ip.convertToByteProcessor());
+                predict(checkDimensions(ip).convertToByteProcessor());
                 break;
             default:
                 String msg = "The predictor only works on 8 and 16-bit images.";

--- a/src/test/java/ch/epfl/leb/defcon/predictors/internal/DefaultPredictorIT.java
+++ b/src/test/java/ch/epfl/leb/defcon/predictors/internal/DefaultPredictorIT.java
@@ -20,6 +20,7 @@ package ch.epfl.leb.defcon.predictors.internal;
 
 import ij.IJ;
 import ij.ImagePlus;
+import ij.process.ImageProcessor;
 import ij.process.FloatProcessor;
 
 import java.io.File;
@@ -100,6 +101,28 @@ public class DefaultPredictorIT {
         
         assertEquals(imp.getHeight(), fp.getHeight());
         assertEquals(imp.getWidth(), fp.getWidth());
+    }
+    
+    /**
+     * Test of getDensityMap method, of class DefaultPredictor.
+     * 
+     * This test verifies that images whose dimensions are not multiples of four
+     * are automatically cropped before computing the density map.
+     */
+    @Test
+    public void testGetDensityMapResized() throws Exception {
+        System.out.println("testGetDensityMapResized");
+        ImageProcessor ip = imp.getProcessor();
+        
+        // Reduce the size of the test data to a non-multiple of four.
+        ip.setRoi(0, 0, ip.getWidth() - 1, ip.getHeight() - 1);
+        
+        predictor.predict(ip.crop());
+        FloatProcessor fp = predictor.getDensityMap();
+        predictor.close();
+        
+        assertEquals(imp.getWidth() - 4, fp.getWidth());
+        assertEquals(imp.getHeight() - 4, fp.getHeight());
     }
 
     /**


### PR DESCRIPTION
### Added

- The `DefaultPredictor` class now automatically crops the input image to dimensions that are a multiple of four.

### Changed

- Moved the exceptions associated with the `Predictor` interface into  the public `predictors` package.