### PR TITLE
Added max. local count methods to the predictor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- Two new methods were added to the `Predictor` interface:
+  `getLocalCountMap()` and `getMaximumLocalCount()`. These allow for a
+  more flexible means for computing maximum local counts than the
+  TensorFlow implementation.
+
 ## [v0.0.2]
 
 ### Added
@@ -25,6 +33,7 @@ All notable changes to this project will be documented in this file.
 
 - Initial project files.
 
+[Unreleased]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/compare/v0.0.2...HEAD
 [v0.0.2]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.2
 [v0.0.1]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.1
 [v0.0.0]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [v0.1.0]
 
 ### Added
 - Two new methods were added to the `Predictor` interface:
@@ -33,7 +33,8 @@ All notable changes to this project will be documented in this file.
 
 - Initial project files.
 
-[Unreleased]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/compare/v0.0.2...HEAD
+[Unreleased]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/compare/v0.1.0...HEAD
+[v0.1.0]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.1.0
 [v0.0.2]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.2
 [v0.0.1]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.1
 [v0.0.0]: https://github.com/LEB-EPFL/DEFCoN-ImageJ/releases/tag/0.0.0

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,9 +26,9 @@ copyright = '2018, The Laboratory of Experimental Biophysics, EPFL, Lausanne, Sw
 author = 'Baptiste Ottino, Kyle M. Douglass'
 
 # The short X.Y version
-version = '0.1.0-SNAPSHOT'
+version = '0.1.0'
 # The full version, including alpha/beta/rc tags
-release = '0.1.0-SNAPSHOT'
+release = '0.1.0'
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,9 +26,9 @@ copyright = '2018, The Laboratory of Experimental Biophysics, EPFL, Lausanne, Sw
 author = 'Baptiste Ottino, Kyle M. Douglass'
 
 # The short X.Y version
-version = '0.0.2'
+version = '0.1.0-SNAPSHOT'
 # The full version, including alpha/beta/rc tags
-release = '0.0.2'
+release = '0.1.0-SNAPSHOT'
 
 
 # -- General configuration ---------------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -7,13 +7,13 @@
     <parent>
 	<groupId>org.scijava</groupId>
 	<artifactId>pom-scijava</artifactId>
-	<version>19.2.0</version>
+	<version>22.3.0</version>
 	<relativePath />
     </parent>
     
     <groupId>ch.epfl.leb</groupId>
     <artifactId>DEFCoN_</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>0.1.0</version>
 
     <name>DEFCoN-ImageJ</name>
     <description>ImageJ plugin for DEFCoN, a fluorescence spot counter using fully convolutional neural networks.</description>

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     
     <groupId>ch.epfl.leb</groupId>
     <artifactId>DEFCoN_</artifactId>
-    <version>0.0.2</version>
+    <version>0.1.0-SNAPSHOT</version>
 
     <name>DEFCoN-ImageJ</name>
     <description>ImageJ plugin for DEFCoN, a fluorescence spot counter using fully convolutional neural networks.</description>

--- a/src/main/java/ch/epfl/leb/defcon/predictors/NoLocalCountMapException.java
+++ b/src/main/java/ch/epfl/leb/defcon/predictors/NoLocalCountMapException.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright (C) 2018 Laboratory of Experimental Biophysics
+ * Ecole Polytechnique Federale de Lausanne (EPFL), Switzerland
+ *
+ * This program is free software: you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see
+ * <http://www.gnu.org/licenses/>.
+ */
+package ch.epfl.leb.defcon.predictors;
+
+/**
+ * Raised when a predictor has not yet made a local count map estimation.
+ * 
+ * @author Kyle M. Douglass
+ */
+public class NoLocalCountMapException extends Exception {
+    
+    public NoLocalCountMapException(String msg) {
+        super(msg);
+    }
+    
+}

--- a/src/main/java/ch/epfl/leb/defcon/predictors/Predictor.java
+++ b/src/main/java/ch/epfl/leb/defcon/predictors/Predictor.java
@@ -51,6 +51,29 @@ public interface Predictor {
     public FloatProcessor getDensityMap() throws UninitializedPredictorException;
     
     /**
+     * Returns the most recently-calculated local count map.
+     * 
+     * @return The most recently calculated local count map.
+     * @throws ch.epfl.leb.defcon.predictors.NoLocalCountMapException
+     */
+    public FloatProcessor getLocalCountMap() throws NoLocalCountMapException;
+    
+    /**
+     * Returns the maximum local count value.
+     * 
+     * This value is obtained by convolving the density map with a square kernel
+     * whose values are all 1 and then taking the maximum of the resulting map.
+     * It effectively produces the highest count value over length scales equal
+     * to the size of the kernel.
+     * 
+     * @param boxSize The width of the square kernel.
+     * @return The maximum local count from the density map.
+     * @throws ch.epfl.leb.defcon.predictors.UninitializedPredictorException
+     */
+    public double getMaximumLocalCount(int boxSize)
+           throws UninitializedPredictorException;
+    
+    /**
      * Makes a density map prediction from a 2D  image.
      * 
      * @param ip The image to perform a prediction on.

--- a/src/test/java/ch/epfl/leb/defcon/predictors/internal/DefaultPredictorIT.java
+++ b/src/test/java/ch/epfl/leb/defcon/predictors/internal/DefaultPredictorIT.java
@@ -20,6 +20,7 @@ package ch.epfl.leb.defcon.predictors.internal;
 
 import ij.IJ;
 import ij.ImagePlus;
+import ij.plugin.SubstackMaker;
 import ij.process.ImageProcessor;
 import ij.process.FloatProcessor;
 
@@ -123,6 +124,56 @@ public class DefaultPredictorIT {
         
         assertEquals(imp.getWidth() - 4, fp.getWidth());
         assertEquals(imp.getHeight() - 4, fp.getHeight());
+    }
+    
+    /**
+     * Test of getLocalCountMap, of class DefaultPredictor.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testGetLocalCountMap() throws Exception {
+        System.out.println("testGetLocalCountMap");
+        SubstackMaker sub = new SubstackMaker();
+        ImagePlus newImp = sub.makeSubstack(imp, "1");
+        ImageProcessor ip = newImp.getProcessor();
+        
+        predictor.predict(ip);
+        int boxSize = 7;
+        double expectedResult = 1.018;
+        predictor.getMaximumLocalCount(boxSize);
+        predictor.close();
+        
+        FloatProcessor fp = predictor.getLocalCountMap();
+        assertEquals(expectedResult, fp.getMax(), 0.001);
+        assertEquals(ip.getWidth() - boxSize + 1, fp.getWidth());
+        assertEquals(ip.getHeight() - boxSize + 1, fp.getHeight());
+    }
+    
+    /**
+     * Test of getMaximumLocalCount, of class DefaultPredictor.
+     * @throws java.lang.Exception
+     */
+    @Test
+    public void testGetMaximumLocalCount() throws Exception {
+        System.out.println("testGetMaximumLocalCount");
+        SubstackMaker sub = new SubstackMaker();
+        ImagePlus newImp = sub.makeSubstack(imp, "1");
+        ImageProcessor ip = newImp.getProcessor();
+        
+        predictor.predict(ip);
+        int boxSize = 7;
+        double expectedResult = 1.018;
+        double result = predictor.getMaximumLocalCount(boxSize);
+        assertEquals(expectedResult, result, 0.001);
+        
+        newImp = sub.makeSubstack(imp, "2");
+        ip = newImp.getProcessor();
+        predictor.predict(ip);
+        expectedResult = 1.023;
+        result = predictor.getMaximumLocalCount(boxSize);
+        assertEquals(expectedResult, result, 0.001);
+        predictor.close();
+
     }
 
     /**


### PR DESCRIPTION
### Added
- Two new methods were added to the `Predictor` interface: `getLocalCountMap()` and `getMaximumLocalCount()`. These allow for a more flexible means for computing maximum local counts than the TensorFlow implementation.